### PR TITLE
remember user selections for coffee, ratio

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,27 +2,27 @@ import * as Fathom from "fathom-client";
 import React, { useEffect, useState } from "react";
 import { Countdown } from "./Countdown";
 import { PourList } from "./PourList";
-
+import { useLocalStorage } from "./useLocalStorage";
 
 function App() {
   const DEFAULT_TIMER = 45;
   const [seconds, setSeconds] = useState(DEFAULT_TIMER);
   const [timerStatus, setTimerStatus] = useState("PENDING");
 
-  const [coffeeAmount, setCoffeeAmount] = useState(15);
-  const [ratioAmount, setRatioAmount] = useState(14);
+  const [coffeeAmount, setCoffeeAmount] = useLocalStorage("coffeeAmount", 15);
+  const [ratioAmount, setRatioAmount] = useLocalStorage("ratioAmount", 14);
 
   function reset() {
     setTimerStatus("PENDING");
     setSeconds(DEFAULT_TIMER);
     setRatioAmount(14);
     setCoffeeAmount(15);
-
+    localStorage.clear();
   }
 
   function stopBloom() {
-      setTimerStatus("PENDING");
-      setSeconds(DEFAULT_TIMER);
+    setTimerStatus("PENDING");
+    setSeconds(DEFAULT_TIMER);
   }
 
   useEffect(() => {
@@ -44,67 +44,68 @@ function App() {
 
   return (
     <div className="bg-gray-900 absolute inset-0 flex justify-center items-center flex-col">
-
       <button
         className="absolute bottom-7 px-5 focus:outline-none bg-opacity-50 text-pink-600 p-2  "
         onClick={reset}
       >
         Reset
       </button>
-      <div
-        className="text-white text-center  cursor-pointer select-none	 absolute top-5 left-5"
-      >
+      <div className="text-white text-center  cursor-pointer select-none	 absolute top-5 left-5">
         <div className="font-bold text-4xl">{coffeeAmount}g</div>
-        <div className="opacity-50 font-light">-  COFFEE  +</div>
-          <div  style={{
-              position: 'absolute',
-              top: '0',
-              width: '100%',
-              height: '70px',
-              left: '-50%',
-          }} onClick={() => {
-              setCoffeeAmount(coffeeAmount - 1);
-          }}></div>
-          <div   style={{
-              position: 'absolute',
-              top: '0',
-              width: '100%',
-              height: '70px',
-              left: '50%',
+        <div className="opacity-50 font-light">- COFFEE +</div>
+        <div
+          style={{
+            position: "absolute",
+            top: "0",
+            width: "100%",
+            height: "70px",
+            left: "-50%",
           }}
-                 onClick={() => {
-                     setCoffeeAmount(coffeeAmount + 5);
-                 }}></div>
-
+          onClick={() => {
+            setCoffeeAmount(coffeeAmount - 1);
+          }}
+        ></div>
+        <div
+          style={{
+            position: "absolute",
+            top: "0",
+            width: "100%",
+            height: "70px",
+            left: "50%",
+          }}
+          onClick={() => {
+            setCoffeeAmount(coffeeAmount + 5);
+          }}
+        ></div>
       </div>
 
-      <div
-        className="text-white m-w-10 text-center  cursor-pointer select-none absolute top-5 right-5"
-
-      >
+      <div className="text-white m-w-10 text-center  cursor-pointer select-none absolute top-5 right-5">
         <div className="font-bold text-4xl">1:{ratioAmount}</div>
-        <div className="opacity-50 font-light">-  RATIO  +</div>
-          <div  style={{
-              position: 'absolute',
-              top: '0',
-              width: '100%',
-              height: '70px',
-              left: '-50%',
-          }} onClick={() => {
-              setRatioAmount(ratioAmount - 1);
-          }}></div>
-          <div   style={{
-              position: 'absolute',
-              top: '0',
-              width: '100%',
-              height: '70px',
-              left: '50%',
+        <div className="opacity-50 font-light">- RATIO +</div>
+        <div
+          style={{
+            position: "absolute",
+            top: "0",
+            width: "100%",
+            height: "70px",
+            left: "-50%",
           }}
-               onClick={() => {
-              setRatioAmount(ratioAmount + 1);
-          }}></div>
-
-
+          onClick={() => {
+            setRatioAmount(ratioAmount - 1);
+          }}
+        ></div>
+        <div
+          style={{
+            position: "absolute",
+            top: "0",
+            width: "100%",
+            height: "70px",
+            left: "50%",
+          }}
+          onClick={() => {
+            setRatioAmount(ratioAmount + 1);
+          }}
+        ></div>
       </div>
 
       <div className="text-white text-center absolute bottom-5 left-5">
@@ -113,7 +114,9 @@ function App() {
       </div>
 
       <div className="text-white  text-center absolute bottom-5 right-5">
-        <div className="font-bold text-4xl">{(coffeeAmount * ratioAmount)/ 5}g</div>
+        <div className="font-bold text-4xl">
+          {(coffeeAmount * ratioAmount) / 5}g
+        </div>
         <div className="text-opacity-40 opacity-50 font-light">PER POUR</div>
       </div>
       {timerStatus === "DONE" ? (

--- a/src/useLocalStorage.js
+++ b/src/useLocalStorage.js
@@ -1,0 +1,20 @@
+// Custom hook that mimics `useState` but also reads/writes values to localStorage
+// Allows us to persist values through refreshes,
+// falling back to an initial value if we haven't set anything
+import { useState } from "react";
+export const useLocalStorage = (key, initialValue) => {
+  const [storedValue, setStoredValue] = useState(
+    localStorage.getItem(key)
+      ? JSON.parse(localStorage.getItem(key))
+      : initialValue
+  );
+
+  // return a setter function that calls the normal setStoredValue (normal useState approach)
+  // but also sets localStorage value
+  const setValue = (value) => {
+    setStoredValue(value);
+    localStorage.setItem(key, JSON.stringify(value));
+  };
+
+  return [storedValue, setValue];
+};


### PR DESCRIPTION
When user changes coffee and ratio, persist those values to localStorage so the values are preserved for next use.

This involves creating a custom hook, that wraps around the functionality of `setState`. 

Note that we still use `setState` inside this hook, but just do some additional work to get and set the value in local storage. When we call our custom hook, the only difference is we designate a key for the localStorage value, but otherwise, the syntax is largely the same.