### PR TITLE
allow user to mark pour steps as complete

### DIFF
--- a/src/PourList.js
+++ b/src/PourList.js
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 export const PourList = ({ coffeeAmount, ratioAmount }) => {
   const steps = calculatePours(coffeeAmount, ratioAmount);
   return (
@@ -9,14 +11,19 @@ export const PourList = ({ coffeeAmount, ratioAmount }) => {
   );
 };
 
-const Pour = ({ step }) => (
-  <div className="mb-4 text-center">
-    <div className="text-sm text-center font-thin uppercase pt-3 text-white">
-      {step.label} Pour to
+const Pour = ({ step }) => {
+  const [done, setDone] = useState(step.label === "Bloom");;
+  return (
+    <div onClick={() => setDone(!done)} className={`mb-4 text-center ${done ? 'opacity-30' : ''}`}>
+      <div className="text-sm text-center font-thin uppercase pt-3 text-white">
+        {step.label} Pour to
+      </div>
+      <div className={`text-4xl text-center font-bold text-white ${done ? 'line-through' : ''}`}>
+        {step.amount}g
+      </div>
     </div>
-    <div className="text-4xl text-center font-bold text-white">{step.amount}g</div>
-  </div>
-);
+  );
+};
 
 const calculatePours = (coffeeAmount, ratioAmount) => {
   // subtract bloom from total


### PR DESCRIPTION
When displaying the list of pours, allow toggling a step as complete by tapping on it.

Here I'm storing a piece of state, which assumes the first step is done (since we usually display the pour list after the bloom step is complete). I'm conditionally applying the tailwind class to adjust opacity and add a strikethrough based on whether the step is `done` or not, using a JS ternary to add that string in, or empty string if its not done.